### PR TITLE
Update user retrieval method to work on Windows.

### DIFF
--- a/cloudlib/logger.py
+++ b/cloudlib/logger.py
@@ -28,6 +28,7 @@ import logging
 import os
 import platform
 import getpass
+import sys
 
 from logging import handlers
 
@@ -172,7 +173,10 @@ class LogSetup(object):
         :param log_dir: ``str``
         :return: ``str``
         """
-        user = getpass.getuser()
+        if sys.platform == 'win32':
+            user = getpass.getuser()
+        else:
+            user = os.getuid()
         home = os.path.expanduser('~')
 
         if not os.path.isdir(log_dir):

--- a/cloudlib/logger.py
+++ b/cloudlib/logger.py
@@ -27,6 +27,7 @@
 import logging
 import os
 import platform
+import getpass
 
 from logging import handlers
 
@@ -171,7 +172,7 @@ class LogSetup(object):
         :param log_dir: ``str``
         :return: ``str``
         """
-        user = os.getuid()
+        user = getpass.getuser()
         home = os.path.expanduser('~')
 
         if not os.path.isdir(log_dir):


### PR DESCRIPTION
Hello Kevin,

I tried to run turbolift on Windows and ran into an issue that seems to be related to the return_logfile method in LogSetup class. More specifically, the problematic line seems to be the following: 

```
    user = os.getuid()
```

Below is the stack trace from the turbolift invocation:

```
turbolift.exe --help

Traceback (most recent call last):
  File "e:\programs\Python\Python27\Scripts\turbolift-script.py", line 9, in <module>
    load_entry_point('turbolift==3.0.0', 'console_scripts', 'turbolift')()
  File "build\bdist.win-amd64\egg\pkg_resources.py", line 351, in load_entry_point
  File "build\bdist.win-amd64\egg\pkg_resources.py", line 2363, in load_entry_point
  File "build\bdist.win-amd64\egg\pkg_resources.py", line 2088, in load
  File "build\bdist.win-amd64\egg\turbolift\executable.py", line 18, in <module>
  File "build\bdist.win-amd64\egg\turbolift\worker.py", line 14, in <module>
  File "build\bdist.win-amd64\egg\turbolift\authentication\auth.py", line 5, in <module>
  File "build\bdist.win-amd64\egg\turbolift\exceptions.py", line 17, in <module>
  File "e:\programs\Python\Python27\lib\site-packages\cloudlib\logger.py", line 82, in getLogger
    return LogSetup().default_logger(name=name.split('.')[0])
  File "e:\programs\Python\Python27\lib\site-packages\cloudlib\logger.py", line 132, in default_logger
    filename=self.return_logfile(filename='%s.log' % name),
  File "e:\programs\Python\Python27\lib\site-packages\cloudlib\logger.py", line 174, in return_logfile
    user = os.getuid()
AttributeError: 'module' object has no attribute 'getuid'

```

Python is not my forte but I managed to fix the issue by replacing the call that retrieves the user with the following call (with import of getpass):

```
    user = getpass.getuser()
```

This is based on the following recommendation: http://stackoverflow.com/questions/842059/is-there-a-portable-way-to-get-the-current-username-in-python
